### PR TITLE
chore(github): enable npm provenance in release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,4 +31,5 @@ jobs:
           publish: npm run changeset:release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Description

Enable npm provenance in github release action.
https://docs.npmjs.com/generating-provenance-statements#using-third-party-package-publishing-tools