### PR TITLE
chore(github): enable permissions for github releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   release:
     permissions:
+      contents: write # Enable permissions for github releases
       id-token: write # OpenID Connect token needed for provenance
     name: Release
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

 Enable permissions for github releases via github actions bot.
 https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token