### PR TITLE
chore(github): enable pull request permissions for github actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
     permissions:
       contents: write # Enable permissions for github releases
       id-token: write # OpenID Connect token needed for provenance
+      pull-requests: write
     name: Release
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Description

Enable pull request permissions for github actions.
https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token